### PR TITLE
Remove absolute path to appspot.com instance

### DIFF
--- a/jsonService/src/main/webapp/password_policy.html
+++ b/jsonService/src/main/webapp/password_policy.html
@@ -115,7 +115,7 @@ under your hand in a row, "4567", then hold shift and do it again "$%^&", then m
 The result is a 16 character password that satisfies most policies.  Passfault recognizes the four horizontal keyboard pattern 
 each with a size of 296, easily cracked, and only detected by passfault.    
 </p> 
-<p><a href="https://passfault.appspot.com/password_strength.html">Test your password strength with passfault
+<p><a href="password_strength.html">Test your password strength with passfault
 </a>
 </p>
 </div>


### PR DESCRIPTION
Should point to the same instance, path must be relative. It looks like the only reference to appspot.